### PR TITLE
logic.rs: use fixed if_then_else from tfhe-rs

### DIFF
--- a/src/ciphertext/logic.rs
+++ b/src/ciphertext/logic.rs
@@ -57,9 +57,5 @@ pub fn binary_if_then_else(
     b: &RadixCiphertext,
     c: &RadixCiphertext,
 ) -> RadixCiphertext {
-    // a * b + (1 - a) * c
-    let a_mul_b = k.k.mul_parallelized(a, b);
-    let not_a = binary_not(k, a);
-    let not_a_mul_c = k.k.mul_parallelized(&not_a, c);
-    k.k.add_parallelized(&a_mul_b, &not_a_mul_c)
+    k.k.if_then_else_parallelized(a, b, c)
 }


### PR DESCRIPTION
There was previously an issue with tfhe-rs's if_then_else_parallelized (tfhe-rs/#615), which prevented its usage here. Now that this has been fixed, there is no loner a need for a custom implementation.