### PR TITLE
logic.rs: use lib functions

### DIFF
--- a/src/ciphertext/logic.rs
+++ b/src/ciphertext/logic.rs
@@ -8,23 +8,17 @@ use super::Uint;
 
 // Returns `not a`, assuming `a` is an encryption of a binary value.
 pub fn binary_not(k: &ServerKey, a: &RadixCiphertext) -> RadixCiphertext {
-    // 1 - a
-    let one = k.create_one();
-    k.k.sub_parallelized(&one, a)
+    k.k.scalar_bitxor_parallelized(a, 1)
 }
 
 // Returns `a or b`, assuming `a` and `b` are encryptions of binary values.
 pub fn binary_or(k: &ServerKey, a: &RadixCiphertext, b: &RadixCiphertext) -> RadixCiphertext {
-    // a + b - a * b
-    let a_add_b = k.k.add_parallelized(a, b);
-    let a_mul_b = k.k.mul_parallelized(a, b);
-    k.k.sub_parallelized(&a_add_b, &a_mul_b)
+    k.k.bitor_parallelized(a, b)
 }
 
 // Returns `a and b`, assuming `a` and `b` are encryptions of binary values.
 pub fn binary_and(k: &ServerKey, a: &RadixCiphertext, b: &RadixCiphertext) -> RadixCiphertext {
-    // a * b
-    k.k.mul_parallelized(a, b)
+    k.k.bitand_parallelized(a, b)
 }
 
 /// Returns 1 if all elements of `v` are equal to 1, or `v.len == 0`. Otherwise


### PR DESCRIPTION
This PR replaces the custom binary functions by the more performant binary functions from `tfhe-rs`.