### PR TITLE
Permit configuration of maximum string length

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,4 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt
+      - run: cargo clippy
       - run: cargo test --release --features "tfhe/x86_64-unix" -- --test-threads=1

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cargo test --release
 cargo test --release -- --test-threads=1
 
 # single test with log
-RUST_LOG=trace RUST_BACKTRACE=1 cargo test --release "ciphertext::tests::insert::add" -- --nocapture --exact
+RUST_LOG=trace RUST_BACKTRACE=1 cargo test --release ciphertext::tests::insert::add -- --nocapture --exact
 
 # all tests with time measurement (nightly only)
 cargo test --release -- --test-threads=1 -Z unstable-options --report-time

--- a/examples/cmd/main.rs
+++ b/examples/cmd/main.rs
@@ -30,6 +30,10 @@ struct Args {
     /// Value used for operations that require parameter `n`.
     #[arg(long, default_value_t = 3)]
     n: usize,
+
+    /// Filter for specific test cases by test case name.
+    #[arg(long)]
+    filter: Option<String>,
 }
 
 fn main() {
@@ -42,6 +46,7 @@ fn main() {
     let pattern = args.pattern;
     let substitution = args.substitution;
     let n = args.n;
+    let filter = args.filter;
 
     println!("Generating keys...");
     let (client_key, server_key) = generate_keys_with_params(PARAM_MESSAGE_2_CARRY_2_KS_PBS);
@@ -509,6 +514,12 @@ fn main() {
 
     let start = Instant::now();
     test_cases.iter().for_each(|t| {
+        if let Some(filter) = &filter {
+            if !(t.name)(&args).contains(filter) {
+                return;
+            }
+        }
+
         let start = Instant::now();
         let result_std = (t.std)(&args);
         let duration_std = start.elapsed();

--- a/src/ciphertext/compare.rs
+++ b/src/ciphertext/compare.rs
@@ -13,8 +13,7 @@ impl FheString {
     /// Returns whether `self` is empty. The result is an encryption of 1 if
     /// this is the case and an encryption of 0 otherwise.
     pub fn is_empty(&self, k: &ServerKey) -> BooleanBlock {
-        let term = k.create_value(Self::TERMINATOR);
-        k.k.eq_parallelized(&self.0[0].0, &term)
+        k.k.scalar_eq_parallelized(&self.0[0].0, Self::TERMINATOR)
     }
 
     /// Returns `self == s`. The result is an encryption of 1 if this is the

--- a/src/ciphertext/compare.rs
+++ b/src/ciphertext/compare.rs
@@ -124,7 +124,7 @@ impl FheString {
 
         let (mut v, overhang_empty) = join(
             || {
-                // v[i] = a[i] == b[i] && b[i] != 0
+                // v[i] = a[i] == b[i] || b[i] == 0
                 a.0.par_iter()
                     .zip(&b.0)
                     .map(|(ai, bi)| {

--- a/src/ciphertext/convert.rs
+++ b/src/ciphertext/convert.rs
@@ -5,7 +5,7 @@ use tfhe::integer::BooleanBlock;
 
 use crate::server_key::ServerKey;
 
-use super::{FheAsciiChar, FheString, Uint};
+use super::{FheAsciiChar, FheString};
 
 impl FheAsciiChar {
     const CASE_DIFF: u8 = 32;
@@ -13,16 +13,16 @@ impl FheAsciiChar {
     /// Returns whether `self` is uppercase.
     pub fn is_uppercase(&self, k: &ServerKey) -> BooleanBlock {
         // (65 <= c <= 90)
-        let c_geq_65 = k.k.scalar_ge_parallelized(&self.0, 65 as Uint);
-        let c_leq_90 = k.k.scalar_le_parallelized(&self.0, 90 as Uint);
+        let c_geq_65 = k.k.scalar_ge_parallelized(&self.0, 65u8);
+        let c_leq_90 = k.k.scalar_le_parallelized(&self.0, 90u8);
         k.k.boolean_bitand(&c_geq_65, &c_leq_90)
     }
 
     /// Returns whether `self` is lowercase.
     pub fn is_lowercase(&self, k: &ServerKey) -> BooleanBlock {
         // (97 <= c <= 122)
-        let c_geq_97 = k.k.scalar_ge_parallelized(&self.0, 97 as u8);
-        let c_leq_122 = k.k.scalar_le_parallelized(&self.0, 122 as u8);
+        let c_geq_97 = k.k.scalar_ge_parallelized(&self.0, 97u8);
+        let c_leq_122 = k.k.scalar_le_parallelized(&self.0, 122u8);
         k.k.boolean_bitand(&c_geq_97, &c_leq_122)
     }
 
@@ -30,7 +30,7 @@ impl FheAsciiChar {
     pub fn to_lowercase(&self, k: &ServerKey) -> FheAsciiChar {
         // c + (c.uppercase ? 32 : 0)
         let ucase = self.is_uppercase(k);
-        let self_add_32 = k.k.scalar_add_parallelized(&self.0, Self::CASE_DIFF as u8);
+        let self_add_32 = k.k.scalar_add_parallelized(&self.0, Self::CASE_DIFF);
         let lcase = k.k.if_then_else_parallelized(&ucase, &self_add_32, &self.0);
         FheAsciiChar(lcase)
     }

--- a/src/ciphertext/insert.rs
+++ b/src/ciphertext/insert.rs
@@ -3,7 +3,7 @@
 use rayon::{join, prelude::*};
 
 use crate::{
-    ciphertext::{logic::if_then_else_zero, FheAsciiChar, Uint},
+    ciphertext::{logic::if_then_else_zero, FheAsciiChar},
     server_key::ServerKey,
 };
 
@@ -58,7 +58,7 @@ impl FheString {
                     .into_par_iter()
                     .map(|i| {
                         let index_add_blen = k.k.add_parallelized(index, &b_len);
-                        k.k.scalar_gt_parallelized(&index_add_blen, i as Uint)
+                        k.k.scalar_gt_parallelized(&index_add_blen, i as u64)
                     })
                     .collect::<Vec<_>>()
             },
@@ -107,7 +107,7 @@ impl FheString {
                 // v[i] = i < index ? a[i] : (i < index + b.len ? b[i - index] : a[i - b.len])
 
                 // c0 = i < index
-                let c0 = k.k.scalar_gt_parallelized(index, i as Uint);
+                let c0 = k.k.scalar_gt_parallelized(index, i as u64);
 
                 // c1 = a[i]
                 let c1 = &a.0[i % a.0.len()].0;

--- a/src/ciphertext/insert.rs
+++ b/src/ciphertext/insert.rs
@@ -5,7 +5,7 @@ use tfhe::integer::RadixCiphertext;
 use rayon::{join, prelude::*};
 
 use crate::{
-    ciphertext::{FheAsciiChar, Uint},
+    ciphertext::{logic::if_then_else_zero, FheAsciiChar, Uint},
     server_key::ServerKey,
 };
 
@@ -33,17 +33,13 @@ impl FheString {
                 let i_lt_n_mul_self_len = k.k.lt_parallelized(&i_radix, &n_mul_self_len);
                 let i_mod_self_len = k.k.rem_parallelized(&i_radix, &self_len);
                 let self_i_mod_self_len = self.char_at(k, &i_mod_self_len);
-                let vi = k.k.if_then_else_parallelized(
-                    &i_lt_n_mul_self_len,
-                    &self_i_mod_self_len.0,
-                    &k.create_zero(),
-                );
+                let vi = if_then_else_zero(k, &i_lt_n_mul_self_len, &self_i_mod_self_len.0);
                 FheAsciiChar(vi)
             })
             .collect::<Vec<_>>();
 
         // Append 0 to terminate string.
-        v.push(FheAsciiChar(k.create_zero()));
+        v.push(Self::term_char(k));
         FheString(v)
     }
 
@@ -125,7 +121,7 @@ impl FheString {
             .collect::<Vec<_>>();
 
         // Append 0 to terminate string.
-        v.push(FheAsciiChar(k.create_zero()));
+        v.push(Self::term_char(k));
         FheString(v)
     }
 }

--- a/src/ciphertext/logic.rs
+++ b/src/ciphertext/logic.rs
@@ -35,10 +35,10 @@ pub fn if_then_else_bool(
     b: &BooleanBlock,
     c: &BooleanBlock,
 ) -> BooleanBlock {
-    let a_and_b = k.k.boolean_bitand(a, b);
-    let not_a = k.k.boolean_bitnot(a);
-    let not_a_and_c = k.k.boolean_bitand(&not_a, c);
-    k.k.boolean_bitor(&a_and_b, &not_a_and_c)
+    let b: RadixCiphertext = b.clone().into_radix(1, &k.k);
+    let c: RadixCiphertext = c.clone().into_radix(1, &k.k);
+    let d = k.k.if_then_else_parallelized(a, &b, &c);
+    BooleanBlock::new_unchecked(d.blocks()[0].clone())
 }
 
 // Returns true if any of the elements of `v` is true.

--- a/src/ciphertext/logic.rs
+++ b/src/ciphertext/logic.rs
@@ -12,7 +12,7 @@ use super::Uint;
 // Returns `a ? b : 0`.
 pub fn if_then_else_zero(k: &ServerKey, a: &BooleanBlock, b: &RadixCiphertext) -> RadixCiphertext {
     let a_radix = a.clone().into_radix(b.blocks().len(), &k.k);
-    k.k.mul_parallelized(&a_radix, &b)
+    k.k.mul_parallelized(&a_radix, b)
 }
 
 // Returns `a ? b : 0`, where `b` is a scalar.

--- a/src/ciphertext/logic.rs
+++ b/src/ciphertext/logic.rs
@@ -7,7 +7,7 @@ use tfhe::integer::{
 
 use crate::server_key::ServerKey;
 
-use super::{FheUsize, Uint};
+use super::FheUsize;
 
 // Returns `a ? b : 0`.
 pub fn if_then_else_zero<T: IntegerRadixCiphertext>(k: &ServerKey, a: &BooleanBlock, b: &T) -> T {
@@ -60,6 +60,6 @@ pub fn all(k: &ServerKey, v: &[BooleanBlock]) -> BooleanBlock {
     let sum = k.k.unchecked_sum_ciphertexts_vec_parallelized(v);
     match sum {
         None => k.k.create_trivial_boolean_block(true),
-        Some(sum) => k.k.scalar_eq_parallelized(&sum, l as Uint),
+        Some(sum) => k.k.scalar_eq_parallelized(&sum, l as u64),
     }
 }

--- a/src/ciphertext/logic.rs
+++ b/src/ciphertext/logic.rs
@@ -2,29 +2,25 @@
 
 use tfhe::integer::{
     block_decomposition::DecomposableInto, server_key::ScalarMultiplier, BooleanBlock,
-    IntegerCiphertext, RadixCiphertext,
+    IntegerCiphertext, IntegerRadixCiphertext, RadixCiphertext,
 };
 
 use crate::server_key::ServerKey;
 
-use super::Uint;
+use super::{FheUsize, Uint};
 
 // Returns `a ? b : 0`.
-pub fn if_then_else_zero(k: &ServerKey, a: &BooleanBlock, b: &RadixCiphertext) -> RadixCiphertext {
+pub fn if_then_else_zero<T: IntegerRadixCiphertext>(k: &ServerKey, a: &BooleanBlock, b: &T) -> T {
     let a_radix = a.clone().into_radix(b.blocks().len(), &k.k);
     k.k.mul_parallelized(&a_radix, b)
 }
 
 // Returns `a ? b : 0`, where `b` is a scalar.
-pub fn scalar_if_then_else_zero<Scalar>(
-    k: &ServerKey,
-    a: &BooleanBlock,
-    b: Scalar,
-) -> RadixCiphertext
+pub fn scalar_if_then_else_zero<Scalar>(k: &ServerKey, a: &BooleanBlock, b: Scalar) -> FheUsize
 where
     Scalar: ScalarMultiplier + DecomposableInto<u8>,
 {
-    let a_radix = a.clone().into_radix(k.num_blocks, &k.k);
+    let a_radix = a.clone().into_radix(k.num_blocks_usize, &k.k);
     k.k.scalar_mul_parallelized(&a_radix, b)
 }
 
@@ -45,12 +41,12 @@ pub fn if_then_else_bool(
 pub fn any(k: &ServerKey, v: &[BooleanBlock]) -> BooleanBlock {
     let v: Vec<RadixCiphertext> = v
         .iter()
-        .map(|vi| vi.clone().into_radix(k.num_blocks, &k.k))
+        .map(|vi| vi.clone().into_radix(k.num_blocks_usize, &k.k))
         .collect();
     let sum = k.k.unchecked_sum_ciphertexts_vec_parallelized(v);
     match sum {
         None => k.k.create_trivial_boolean_block(false),
-        Some(sum) => k.k.scalar_gt_parallelized(&sum, 0 as Uint),
+        Some(sum) => k.k.scalar_gt_parallelized(&sum, 0u8),
     }
 }
 
@@ -58,7 +54,7 @@ pub fn any(k: &ServerKey, v: &[BooleanBlock]) -> BooleanBlock {
 pub fn all(k: &ServerKey, v: &[BooleanBlock]) -> BooleanBlock {
     let v: Vec<RadixCiphertext> = v
         .iter()
-        .map(|vi| vi.clone().into_radix(k.num_blocks, &k.k))
+        .map(|vi| vi.clone().into_radix(k.num_blocks_usize, &k.k))
         .collect();
     let l = v.len();
     let sum = k.k.unchecked_sum_ciphertexts_vec_parallelized(v);

--- a/src/ciphertext/replace.rs
+++ b/src/ciphertext/replace.rs
@@ -100,7 +100,7 @@ impl FheString {
         });
 
         // Append 0 to terminate string.
-        v.push(FheAsciiChar(k.create_zero()));
+        v.push(Self::term_char(k));
         FheString(v)
     }
 }

--- a/src/ciphertext/replace.rs
+++ b/src/ciphertext/replace.rs
@@ -6,7 +6,6 @@ use crate::{
     ciphertext::{
         element_at_bool,
         logic::{if_then_else_bool, if_then_else_zero},
-        Uint,
     },
     server_key::ServerKey,
 };
@@ -68,7 +67,7 @@ impl FheString {
 
             // c = i + n * len_diff
             let n_mul_lendiff = k.k.mul_parallelized(&n, &len_diff);
-            let c = k.k.scalar_add_parallelized(&n_mul_lendiff, i as Uint);
+            let c = k.k.scalar_add_parallelized(&n_mul_lendiff, i as u64);
 
             let j_lt_slen = k.k.lt_parallelized(&j, &s_len);
             let match_and_jltslen = k.k.boolean_bitand(&in_match, &j_lt_slen);
@@ -96,7 +95,7 @@ impl FheString {
             let vi = k.k.if_then_else_parallelized(&in_match, &sj, &self_c);
             v.push(FheAsciiChar(vi));
 
-            j = k.k.scalar_add_parallelized(&j, 1 as Uint);
+            j = k.k.scalar_add_parallelized(&j, 1u8);
         });
 
         // Append 0 to terminate string.

--- a/src/ciphertext/replace.rs
+++ b/src/ciphertext/replace.rs
@@ -1,6 +1,6 @@
 //! Functionality for string replacement.
 
-use tfhe::integer::{IntegerCiphertext, RadixCiphertext};
+use tfhe::integer::IntegerCiphertext;
 
 use crate::{
     ciphertext::{
@@ -11,7 +11,7 @@ use crate::{
     server_key::ServerKey,
 };
 
-use super::{FheAsciiChar, FheString};
+use super::{FheAsciiChar, FheString, FheUsize};
 
 impl FheString {
     /// Returns `self` where `p` is replaced by `s` up to length `l`.
@@ -26,7 +26,7 @@ impl FheString {
         k: &ServerKey,
         p: &FheString,
         s: &FheString,
-        n_max: &RadixCiphertext,
+        n_max: &FheUsize,
         l: usize,
     ) -> FheString {
         self.replace_opt(k, p, s, Some(n_max), l)
@@ -40,7 +40,7 @@ impl FheString {
         k: &ServerKey,
         p: &FheString,
         s: &FheString,
-        n_max: Option<&RadixCiphertext>,
+        n_max: Option<&FheUsize>,
         l: usize,
     ) -> FheString {
         let l = std::cmp::min(l, Self::max_len_with_key(k));
@@ -60,8 +60,8 @@ impl FheString {
             j += 1
          */
         let mut in_match = k.k.create_trivial_boolean_block(false);
-        let mut j = k.create_zero();
-        let mut n = k.create_zero();
+        let mut j = FheUsize::new_trivial(k, 0);
+        let mut n = FheUsize::new_trivial(k, 0);
         let mut v = Vec::<FheAsciiChar>::new();
         (0..l).for_each(|i| {
             log::trace!("replace_nopt: at index {i}");

--- a/src/ciphertext/search.rs
+++ b/src/ciphertext/search.rs
@@ -3,10 +3,7 @@
 use rayon::prelude::*;
 use tfhe::integer::BooleanBlock;
 
-use crate::{
-    ciphertext::{logic::all, Uint},
-    server_key::ServerKey,
-};
+use crate::{ciphertext::logic::all, server_key::ServerKey};
 
 use super::{
     index_of_unchecked,
@@ -101,7 +98,7 @@ impl FheString {
                 in_match = if_then_else_bool(k, &in_match, &in_match, mi);
 
                 // j += 1
-                k.k.scalar_add_assign_parallelized(&mut j, 1 as Uint);
+                k.k.scalar_add_assign_parallelized(&mut j, 1u8);
 
                 // in_match = in_match && j < s.len
                 let j_lt_slen = k.k.lt_parallelized(&j, &s_len);
@@ -147,7 +144,7 @@ impl FheString {
                 j = k.k.if_then_else_parallelized(&j_lt_slen_and_mi, &zero, &j);
 
                 // j += 1
-                k.k.scalar_add_assign_parallelized(&mut j, 1 as Uint);
+                k.k.scalar_add_assign_parallelized(&mut j, 1u8);
 
                 mi
             })
@@ -189,7 +186,7 @@ impl FheString {
         let subvec = &self.0.get(i..).unwrap_or_default();
         let index = index_of_unchecked(k, subvec, p);
         // Add offset.
-        let val = k.k.scalar_add_parallelized(&index.val, i as Uint);
+        let val = k.k.scalar_add_parallelized(&index.val, i as u64);
         FheOption {
             is_some: index.is_some,
             val,

--- a/src/ciphertext/search.rs
+++ b/src/ciphertext/search.rs
@@ -236,7 +236,7 @@ impl FheString {
                     .map(|(ai, bi)| {
                         let eq = k.k.eq_parallelized(&ai.0, &bi.0);
                         let is_term = &k.k.scalar_eq_parallelized(&ai.0, FheString::TERMINATOR);
-                        k.k.boolean_bitor(&eq, &is_term)
+                        k.k.boolean_bitor(&eq, is_term)
                     })
                     .collect::<Vec<_>>();
                 all(k, &v)

--- a/src/ciphertext/split.rs
+++ b/src/ciphertext/split.rs
@@ -437,10 +437,9 @@ impl FheString {
         let whitespace = self.find_all_pred_unchecked(k, is_whitespace);
         let next_whitespace = self.find_all_next_pred_unchecked(k, is_whitespace);
 
-        let zero = k.create_zero();
         let opt_default = FheOption {
             is_some: k.k.create_trivial_boolean_block(false),
-            val: zero.clone(),
+            val: k.create_zero(),
         };
 
         let self_len = self.len(k);

--- a/src/ciphertext/split.rs
+++ b/src/ciphertext/split.rs
@@ -5,7 +5,7 @@ use tfhe::integer::IntegerCiphertext;
 
 use crate::{ciphertext::element_at_bool, client_key::ClientKey, server_key::ServerKey};
 
-use super::{FheAsciiChar, FheOption, FheString, FheUsize, Uint};
+use super::{FheAsciiChar, FheOption, FheString, FheUsize};
 
 /// An element of an `FheStringSliceVector`.
 #[derive(Clone)]
@@ -269,7 +269,7 @@ impl FheString {
         let self_len = self.len(k);
 
         let n = self.max_len() + 2; // Maximum number of entries.
-        let n_hidden = k.k.scalar_add_parallelized(&self_len, 2 as Uint); // Better bound based on hidden length.
+        let n_hidden = k.k.scalar_add_parallelized(&self_len, 2u8); // Better bound based on hidden length.
         let mut next_match = self_len.clone();
         let mut elems = (0..n)
             .rev()
@@ -283,13 +283,13 @@ impl FheString {
                     let i_radix = FheUsize::new_trivial(k, i);
                     let i_sub_plen = k.k.sub_parallelized(&i_radix, &p_len);
                     let mi = element_at_bool(k, &matches, &i_sub_plen);
-                    let i_lt_n_hidden = k.k.scalar_gt_parallelized(&n_hidden, i as Uint);
+                    let i_lt_n_hidden = k.k.scalar_gt_parallelized(&n_hidden, i as u64);
                     k.k.boolean_bitand(&i_lt_n_hidden, &mi)
                 };
 
                 // next_match_target = i + (inclusive ? p.len : 0)
                 let next_match_target = if inclusive {
-                    k.k.scalar_add_parallelized(&p_len, i as Uint)
+                    k.k.scalar_add_parallelized(&p_len, i as u64)
                 } else {
                     FheUsize::new_trivial(k, i)
                 };

--- a/src/ciphertext/split.rs
+++ b/src/ciphertext/split.rs
@@ -1,20 +1,20 @@
 //! Functionality for string splitting.
 
 use rayon::prelude::*;
-use tfhe::integer::{IntegerCiphertext, RadixCiphertext};
+use tfhe::integer::IntegerCiphertext;
 
 use crate::{ciphertext::element_at_bool, client_key::ClientKey, server_key::ServerKey};
 
-use super::{FheAsciiChar, FheOption, FheString, Uint};
+use super::{FheAsciiChar, FheOption, FheString, FheUsize, Uint};
 
 /// An element of an `FheStringSliceVector`.
 #[derive(Clone)]
 struct FheStringSlice {
     /// The start index of the string slice.
-    start: RadixCiphertext,
+    start: FheUsize,
 
     /// The end index of the string slice, exclusive.
-    end: RadixCiphertext,
+    end: FheUsize,
 }
 
 /// An encrypted vector of substrings of an encrypted reference string.
@@ -29,25 +29,28 @@ pub struct FheStringSliceVector {
 
 impl FheStringSliceVector {
     /// Returns the number of substrings contained in this vector.
-    pub fn len(&self, k: &ServerKey) -> RadixCiphertext {
+    pub fn len(&self, k: &ServerKey) -> FheUsize {
         let v = self
             .v
             .par_iter()
-            .map(|vi| vi.is_some.clone().into_radix(k.num_blocks, &k.k))
+            .map(|vi| FheUsize::new_from_bool(k, &vi.is_some)) // (vi.is_some.clone().into_radix(k.num_blocks_usize, &k.k))
             .collect::<Vec<_>>();
-        k.k.unchecked_sum_ciphertexts_vec_parallelized(v)
-            .unwrap_or(k.create_zero())
+        let l = k.k.unchecked_sum_ciphertexts_vec_parallelized(v);
+        match l {
+            Some(l) => l,
+            None => FheUsize::new_trivial(k, 0),
+        }
     }
 
     /// Returns the substring stored at index `i`, if existent.
-    pub fn get(&self, k: &ServerKey, i: &RadixCiphertext) -> FheOption<FheString> {
-        let mut n = k.create_zero();
+    pub fn get(&self, k: &ServerKey, i: &FheUsize) -> FheOption<FheString> {
+        let mut n = FheUsize::new_trivial(k, 0);
 
         let init = FheOption {
             is_some: k.k.create_trivial_boolean_block(false),
             val: FheStringSlice {
-                start: k.create_zero(),
-                end: k.create_zero(),
+                start: FheUsize::new_trivial(k, 0),
+                end: FheUsize::new_trivial(k, 0),
             },
         };
 
@@ -55,7 +58,7 @@ impl FheStringSliceVector {
             // acc = i == n && vi.is_some ? (j, vi.end) : acc
             let i_eq_n = k.k.eq_parallelized(i, &n);
             let is_some = k.k.boolean_bitand(&i_eq_n, &vi.is_some);
-            let j_radix = k.create_value(j as Uint);
+            let j_radix = FheUsize::new_trivial(k, j);
             let start =
                 k.k.if_then_else_parallelized(&is_some, &j_radix, &acc.val.start);
             let end =
@@ -80,14 +83,14 @@ impl FheStringSliceVector {
     }
 
     /// Truncates `self` starting from index `i`.
-    pub fn truncate(&mut self, k: &ServerKey, i: &RadixCiphertext) {
+    pub fn truncate(&mut self, k: &ServerKey, i: &FheUsize) {
         /*
         n = 0
         for i in v.len:
             v[i] = v[i] if n < i else (0, 0)
             n += v[i].is_start
         */
-        let mut n = k.create_zero();
+        let mut n = FheUsize::new_trivial(k, 0);
 
         self.v = self
             .v
@@ -144,7 +147,7 @@ impl FheStringSliceVector {
     fn expand_first(&mut self, k: &ServerKey) {
         // Find the first item and set its start point to 0.
         let mut not_found = k.k.create_trivial_boolean_block(true);
-        let zero = k.create_zero();
+        let zero = FheUsize::new_trivial(k, 0);
         self.v = self
             .v
             .iter()
@@ -207,12 +210,12 @@ impl FheStringSliceVector {
         self.v
             .iter()
             .filter_map(|vi| {
-                let is_some = k.0.decrypt_bool(&vi.is_some);
+                let is_some = k.k.decrypt_bool(&vi.is_some);
                 match is_some {
                     false => None,
                     true => {
-                        let start = k.0.decrypt::<Uint>(&vi.val.start) as usize;
-                        let end = k.0.decrypt::<Uint>(&vi.val.end) as usize;
+                        let start = vi.val.start.decrypt(k);
+                        let end = vi.val.end.decrypt(k);
                         let slice = s_dec.get(start..end).unwrap_or_default();
                         log::trace!("decrypt slice: [{start}, {end}]");
                         Some(slice.to_string())
@@ -277,7 +280,7 @@ impl FheString {
                 let is_some = if i == 0 {
                     k.k.create_trivial_boolean_block(true)
                 } else {
-                    let i_radix = k.create_value(i as Uint);
+                    let i_radix = FheUsize::new_trivial(k, i);
                     let i_sub_plen = k.k.sub_parallelized(&i_radix, &p_len);
                     let mi = element_at_bool(k, &matches, &i_sub_plen);
                     let i_lt_n_hidden = k.k.scalar_gt_parallelized(&n_hidden, i as Uint);
@@ -288,7 +291,7 @@ impl FheString {
                 let next_match_target = if inclusive {
                     k.k.scalar_add_parallelized(&p_len, i as Uint)
                 } else {
-                    k.create_value(i as Uint)
+                    FheUsize::new_trivial(k, i)
                 };
 
                 // next_match[i] = matches[i] ? next_match_target : next_match[i+1]
@@ -299,10 +302,10 @@ impl FheString {
 
                 // start = max(i - p.empty, 0)
                 let start = if i > 0 {
-                    let pattern_empty_radix = pattern_empty.clone().into_radix(k.num_blocks, &k.k);
-                    k.k.sub_parallelized(&k.create_value(i as Uint), &pattern_empty_radix)
+                    let pattern_empty_radix = FheUsize::new_from_bool(k, &pattern_empty);
+                    k.k.sub_parallelized(&FheUsize::new_trivial(k, i), &pattern_empty_radix)
                 } else {
-                    k.create_zero()
+                    FheUsize::new_trivial(k, 0)
                 };
 
                 FheOption {
@@ -362,12 +365,7 @@ impl FheString {
     ///
     /// # Limitations
     /// If p.len == 0, the result is undefined.
-    pub fn splitn(
-        &self,
-        k: &ServerKey,
-        n: &RadixCiphertext,
-        p: &FheString,
-    ) -> FheStringSliceVector {
+    pub fn splitn(&self, k: &ServerKey, n: &FheUsize, p: &FheString) -> FheStringSliceVector {
         let mut v = self.split(k, p);
         v.truncate(k, n);
         v.expand_last(k);
@@ -379,12 +377,7 @@ impl FheString {
     ///
     /// # Limitations
     /// If p.len == 0, the result is undefined.
-    pub fn rsplitn(
-        &self,
-        k: &ServerKey,
-        n: &RadixCiphertext,
-        p: &FheString,
-    ) -> FheStringSliceVector {
+    pub fn rsplitn(&self, k: &ServerKey, n: &FheUsize, p: &FheString) -> FheStringSliceVector {
         let mut v = self.rsplit(k, p);
         v.truncate(k, n);
         v.reverse();
@@ -439,7 +432,7 @@ impl FheString {
 
         let opt_default = FheOption {
             is_some: k.k.create_trivial_boolean_block(false),
-            val: k.create_zero(),
+            val: FheUsize::new_trivial(k, 0),
         };
 
         let self_len = self.len(k);
@@ -469,7 +462,7 @@ impl FheString {
                 FheOption {
                     is_some,
                     val: FheStringSlice {
-                        start: k.create_value(i as Uint),
+                        start: FheUsize::new_trivial(k, i),
                         end,
                     },
                 }

--- a/src/ciphertext/tests/insert.rs
+++ b/src/ciphertext/tests/insert.rs
@@ -1,6 +1,9 @@
 use std::ops::Add;
 
-use crate::ciphertext::tests::{encrypt_int, encrypt_string, setup};
+use crate::{
+    ciphertext::tests::{encrypt_string, setup},
+    FheUsize,
+};
 
 #[test]
 fn add() {
@@ -93,7 +96,7 @@ fn repeat() {
 
     test_cases.iter().for_each(|t| {
         let a_enc = encrypt_string(&client_key, t.a, t.a_pad);
-        let n_enc = encrypt_int(&client_key, t.n as u64);
+        let n_enc = FheUsize::new(&client_key, t.n);
 
         let result = t.a.repeat(t.n);
 

--- a/src/ciphertext/tests/replace.rs
+++ b/src/ciphertext/tests/replace.rs
@@ -1,6 +1,6 @@
-use crate::ciphertext::{
-    tests::{encrypt_int, encrypt_string, setup},
-    FheString,
+use crate::{
+    ciphertext::tests::{encrypt_string, setup},
+    FheUsize,
 };
 
 #[test]
@@ -48,10 +48,6 @@ fn replace() {
         let replace_enc = encrypt_string(&client_key, t.replace, t.pad);
 
         let result = t.input.replace(t.pattern, t.replace);
-
-        // Cap at max length.
-        let l = std::cmp::min(result.len(), FheString::max_len_with_key(&server_key));
-        let result = result[..l].to_string();
 
         let result_enc = input_enc.replace(&server_key, &pattern_enc, &replace_enc, result.len());
         let result_dec = result_enc.decrypt(&client_key);
@@ -105,13 +101,9 @@ fn replacen() {
         let input_enc = encrypt_string(&client_key, t.input, t.pad);
         let pattern_enc = encrypt_string(&client_key, t.pattern, t.pad);
         let replace_enc = encrypt_string(&client_key, t.replace, t.pad);
-        let n_enc = encrypt_int(&client_key, t.n as u64);
+        let n_enc = FheUsize::new(&client_key, t.n);
 
         let result = t.input.replacen(t.pattern, t.replace, t.n);
-
-        // Cap at max length.
-        let l = std::cmp::min(result.len(), FheString::max_len_with_key(&server_key));
-        let result = result[..l].to_string();
 
         let result_enc = input_enc.replacen(
             &server_key,

--- a/src/ciphertext/tests/search.rs
+++ b/src/ciphertext/tests/search.rs
@@ -1,4 +1,4 @@
-use crate::ciphertext::tests::{decrypt_bool, decrypt_option_int, encrypt_string, setup};
+use crate::ciphertext::tests::{decrypt_bool, encrypt_string, setup};
 
 #[test]
 fn find_rfind_contains() {
@@ -47,7 +47,7 @@ fn find_rfind_contains() {
         let result = t.a.find(t.b);
 
         let result_enc = a_enc.find(&server_key, &b_enc);
-        let result_dec = decrypt_option_int(&client_key, &result_enc);
+        let result_dec = result_enc.decrypt(&client_key);
 
         println!("find: {:?}", t);
         println!("std = {:?}", result);
@@ -59,7 +59,7 @@ fn find_rfind_contains() {
         let result = t.a.rfind(t.b);
 
         let result_enc = a_enc.rfind(&server_key, &b_enc);
-        let result_dec = decrypt_option_int(&client_key, &result_enc);
+        let result_dec = result_enc.decrypt(&client_key);
 
         println!("rfind: {:?}", t);
         println!("std = {:?}", result);

--- a/src/ciphertext/tests/split.rs
+++ b/src/ciphertext/tests/split.rs
@@ -1,4 +1,7 @@
-use crate::ciphertext::tests::{encrypt_int, encrypt_string, setup};
+use crate::{
+    ciphertext::tests::{encrypt_string, setup},
+    FheUsize,
+};
 
 #[test]
 fn split() {
@@ -103,7 +106,7 @@ fn splitn() {
     test_cases.iter().enumerate().for_each(|(i, t)| {
         let input_enc = encrypt_string(&client_key, t.input, t.pad);
         let pattern_enc = encrypt_string(&client_key, t.pattern, t.pad);
-        let n_enc = encrypt_int(&client_key, t.n as u64);
+        let n_enc = FheUsize::new(&client_key, t.n);
 
         let result = t.input.splitn(t.n, t.pattern).collect::<Vec<_>>();
 
@@ -424,7 +427,7 @@ fn rsplitn() {
     test_cases.iter().enumerate().for_each(|(i, t)| {
         let input_enc = encrypt_string(&client_key, t.input, t.pad);
         let pattern_enc = encrypt_string(&client_key, t.pattern, t.pad);
-        let n_enc = encrypt_int(&client_key, t.n as u64);
+        let n_enc = FheUsize::new(&client_key, t.n);
 
         let result = t.input.rsplitn(t.n, t.pattern).collect::<Vec<_>>();
 
@@ -483,7 +486,7 @@ fn split_once() {
             .map(|v| (v.0.to_string(), v.1.to_string()));
 
         let opt_v_enc = input_enc.split_once(&server_key, &pattern_enc);
-        let b_dec = client_key.0.decrypt_bool(&opt_v_enc.is_some);
+        let b_dec = client_key.k.decrypt_bool(&opt_v_enc.is_some);
         let val0_dec = opt_v_enc.val.0.decrypt(&client_key);
         let val1_dec = opt_v_enc.val.1.decrypt(&client_key);
         let opt_v_dec = match b_dec {
@@ -543,7 +546,7 @@ fn rsplit_once() {
             .map(|v| (v.0.to_string(), v.1.to_string()));
 
         let opt_v_enc = input_enc.rsplit_once(&server_key, &pattern_enc);
-        let b_dec = client_key.0.decrypt_bool(&opt_v_enc.is_some);
+        let b_dec = client_key.k.decrypt_bool(&opt_v_enc.is_some);
         let val0_dec = opt_v_enc.val.0.decrypt(&client_key);
         let val1_dec = opt_v_enc.val.1.decrypt(&client_key);
         let opt_v_dec = match b_dec {

--- a/src/ciphertext/tests/trim.rs
+++ b/src/ciphertext/tests/trim.rs
@@ -1,4 +1,4 @@
-use crate::ciphertext::tests::{decrypt_option_string, encrypt_string, setup};
+use crate::ciphertext::tests::{encrypt_string, setup};
 
 #[test]
 fn trim_trim_start_trim_end() {
@@ -125,7 +125,7 @@ fn strip_prefix_strip_suffix() {
         let result = t.a.strip_prefix(t.b).map(|s| s.to_string());
 
         let result_enc = a_enc.strip_prefix(&server_key, &b_enc);
-        let result_dec = decrypt_option_string(&client_key, &result_enc);
+        let result_dec = result_enc.decrypt(&client_key);
 
         println!("strip_prefix: {:?}", t);
         println!("std = {:?}", result);
@@ -137,7 +137,7 @@ fn strip_prefix_strip_suffix() {
         let result = t.a.strip_suffix(t.b).map(|s| s.to_string());
 
         let result_enc = a_enc.strip_suffix(&server_key, &b_enc);
-        let result_dec = decrypt_option_string(&client_key, &result_enc);
+        let result_dec = result_enc.decrypt(&client_key);
 
         println!("strip_suffix: {:?}", t);
         println!("std = {:?}", result);

--- a/src/ciphertext/trim.rs
+++ b/src/ciphertext/trim.rs
@@ -1,13 +1,13 @@
 //! Functionality for string trimming.
 
 use rayon::{join, prelude::*};
-use tfhe::integer::{BooleanBlock, RadixCiphertext};
+use tfhe::integer::BooleanBlock;
 
 use crate::server_key::ServerKey;
 
 use super::{
     index_of_unchecked, logic::if_then_else_zero, rindex_of_unchecked, FheAsciiChar, FheOption,
-    FheString, Uint,
+    FheString, FheUsize, Uint,
 };
 
 impl FheAsciiChar {
@@ -116,7 +116,7 @@ impl FheString {
     }
 
     /// Returns `self[..index]`.
-    pub fn truncate(&self, k: &ServerKey, index: &RadixCiphertext) -> FheString {
+    pub fn truncate(&self, k: &ServerKey, index: &FheUsize) -> FheString {
         let v = self
             .0
             .par_iter()

--- a/src/ciphertext/trim.rs
+++ b/src/ciphertext/trim.rs
@@ -7,7 +7,7 @@ use crate::server_key::ServerKey;
 
 use super::{
     index_of_unchecked, logic::if_then_else_zero, rindex_of_unchecked, FheAsciiChar, FheOption,
-    FheString, FheUsize, Uint,
+    FheString, FheUsize,
 };
 
 impl FheAsciiChar {
@@ -17,10 +17,10 @@ impl FheAsciiChar {
         // (Vertical tab), 12 (Form feed), 13 (Carriage return), 32 (Space)
 
         // (9 <= c <= 13) || c == 32
-        let c_geq_9 = k.k.scalar_ge_parallelized(&self.0, 9 as Uint);
-        let c_leq_13 = k.k.scalar_le_parallelized(&self.0, 13 as Uint);
+        let c_geq_9 = k.k.scalar_ge_parallelized(&self.0, 9u8);
+        let c_leq_13 = k.k.scalar_le_parallelized(&self.0, 13u8);
         let c_geq_9_and_c_leq_13 = k.k.boolean_bitand(&c_geq_9, &c_leq_13);
-        let c_eq_32 = k.k.scalar_eq_parallelized(&self.0, 32 as Uint);
+        let c_eq_32 = k.k.scalar_eq_parallelized(&self.0, 32u8);
         k.k.boolean_bitor(&c_geq_9_and_c_leq_13, &c_eq_32)
     }
 }
@@ -123,7 +123,7 @@ impl FheString {
             .enumerate()
             .map(|(i, c)| {
                 // a[i] = i < index ? a[i] : 0
-                let i_lt_index = k.k.scalar_gt_parallelized(index, i as Uint);
+                let i_lt_index = k.k.scalar_gt_parallelized(index, i as u64);
                 let ai = if_then_else_zero(k, &i_lt_index, &c.0);
                 FheAsciiChar(ai)
             })

--- a/src/server_key.rs
+++ b/src/server_key.rs
@@ -3,9 +3,7 @@
 
 use std::fmt::Debug;
 
-use tfhe::integer::{
-    block_decomposition::DecomposableInto, RadixCiphertext, ServerKey as IntegerServerKey,
-};
+use tfhe::integer::ServerKey as IntegerServerKey;
 
 use crate::client_key::Key;
 
@@ -13,8 +11,9 @@ use crate::client_key::Key;
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ServerKey {
     pub(crate) k: IntegerServerKey,
-    pub(crate) num_blocks: usize,
     pub(crate) msg_mod: usize,
+    pub(crate) num_blocks_char: usize,
+    pub(crate) num_blocks_usize: usize,
 }
 
 impl Debug for ServerKey {
@@ -23,25 +22,12 @@ impl Debug for ServerKey {
     }
 }
 
-impl ServerKey {
-    /// Returns a trivial ciphertext with value `0`.
-    pub fn create_zero(&self) -> RadixCiphertext {
-        self.k.create_trivial_zero_radix(self.num_blocks)
-    }
-
-    /// Returns a trivial ciphertext with value `1`.
-    pub fn create_one(&self) -> RadixCiphertext {
-        self.k.create_trivial_radix(1u8, self.num_blocks)
-    }
-
-    /// Returns a trivial ciphertext with value `v`.
-    pub fn create_value<T: DecomposableInto<u64>>(&self, v: T) -> RadixCiphertext {
-        self.k.create_trivial_radix(v, self.num_blocks)
-    }
-}
-
 impl Key for ServerKey {
-    fn max_int(&self) -> usize {
-        self.msg_mod.pow(self.num_blocks as u32) - 1
+    fn msg_mod(&self) -> usize {
+        self.msg_mod
+    }
+
+    fn num_blocks_usize(&self) -> usize {
+        self.num_blocks_usize
     }
 }

--- a/src/server_key.rs
+++ b/src/server_key.rs
@@ -26,20 +26,17 @@ impl Debug for ServerKey {
 impl ServerKey {
     /// Returns a trivial ciphertext with value `0`.
     pub fn create_zero(&self) -> RadixCiphertext {
-        self.k
-            .create_trivial_zero_radix::<RadixCiphertext>(self.num_blocks)
+        self.k.create_trivial_zero_radix(self.num_blocks)
     }
 
     /// Returns a trivial ciphertext with value `1`.
     pub fn create_one(&self) -> RadixCiphertext {
-        self.k
-            .create_trivial_radix::<u8, RadixCiphertext>(1, self.num_blocks)
+        self.k.create_trivial_radix(1u8, self.num_blocks)
     }
 
     /// Returns a trivial ciphertext with value `v`.
     pub fn create_value<T: DecomposableInto<u64>>(&self, v: T) -> RadixCiphertext {
-        self.k
-            .create_trivial_radix::<T, RadixCiphertext>(v, self.num_blocks)
+        self.k.create_trivial_radix(v, self.num_blocks)
     }
 }
 


### PR DESCRIPTION
Introduces type `FheUsize`.

- Used for representing encrypted string indices.
- The width of this type can be configured when generating keys.